### PR TITLE
Session: Implement session build transactions.

### DIFF
--- a/include/libobmcsession/obmcsession.h
+++ b/include/libobmcsession/obmcsession.h
@@ -1,0 +1,272 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (C) 2021 YADRO.
+ */
+
+#pragma once
+
+#if (defined __cplusplus)
+extern "C"
+{
+#endif
+
+#include <libobmcsession/obmcsession_proto.h>
+#include <systemd/sd-bus.h>
+
+/** @brief Constructs session manager
+ *
+ * @param[in] bus           - Handle to system dbus
+ * @param[in] objPath       - The Dbus service slug uniquely identifying the
+ *                            source of a session to create the appropriate
+ *                            items from. Service name template:
+ *                            'xyz.openbmc_project.Session.${slug}'.
+ * @param[in] type          - Type of all session items that will be created
+ *                            by the current instance.
+ * @return int              - session manager initialization status
+ */
+extern int obmcsesManagerInit(sd_bus* bus, const char* slug,
+                                obmcsessType type);
+
+/**
+ * @brief Deinitialize session manager, release all accepted resources.
+ * 
+ * @return int 
+ */
+extern void obmcsesManagerClose();
+
+/**
+ * @brief Create a session and publish into the dbus.
+ *
+ * @param[in] userName      - the owner user name
+ * @param[in] remoteAddress - the IP address of the session initiator.
+ * @param[out] sessionId    - unique session ID
+ *
+ * @return int              - session build status
+ */
+extern int obmcsesCreate(const char* userName, const char* remoteAddress,
+                            obmcsesSessionId* sessionId);
+
+/**
+ * @brief Create a session and publish into the dbus without appropriate
+ *        session payload
+ *
+ * @param[out] sessionId    - unique session ID
+ *
+ * @note The session is incomplete. Metadata of session must be set for 10
+ *       seconds. Otherwise, the current session will be closed. All other
+ *       new session creates requests will be rejected until the current
+ *       created session accepts metadata or is removed by timeout.
+ *
+ * @return int              - session build status
+ */
+extern int obmcsesCreateTransaction(obmcsesSessionId* sessionId);
+
+/**
+ * @brief Create a session and publish into the dbus without appropriate
+ *        session payload
+ *
+ * @param[in] cleanupFn             - the callback to cleanup session on
+ *                                    destroy.
+ * @param[out] SessionIdentifier    - unique session ID
+ *
+ * @note The session is incomplete. Metadata of session must be set for 10
+ *       seconds. Otherwise, the current session will be closed. All other
+ *       new session creates requests will be rejected until the current
+ *       created session accepts metadata or is removed by timeout.
+ *
+ * @return int                      - session build status
+ */
+extern int obmcsesCreateTransactionWithCleanup(obmcsesCleanupFn cleanupFn,
+                                                obmcsesSessionId* sessionId);
+
+/**
+ * @brief Create a session and publish into the dbus with cleanup callback
+ *        on the session destroy.
+ *
+ * @param[in] userName              - the owner user name
+ * @param[in] remoteAddress         - the IP address of the session
+ *                                    initiator.
+ * @param[in] cleanupFn             - the callback to cleanup session on
+ *                                    destroy.
+ * @param[out] SessionIdentifier    - unique session ID
+ *
+ * @return int                      - session build status
+ */
+extern int obmcsesCreateWithCleanup(const char* userName,
+                                    const char* remoteAddress,
+                                    obmcsesCleanupFn cleanupFn,
+                                    obmcsesSessionId* sessionId);
+
+/** @brief Commit the pending session build that is handle by the current
+ *         manager.
+ *
+ *  @param[in] username     - the owner username of the session.
+ *  @param[in] remoteIPAddr - the IP address of the session initiator.
+ *
+ *  @return int             - session build status
+ */
+extern int obmcsesCommitSessionBuild(const char* username,
+                                        const char* remoteIPAddr);
+
+/** @brief Commit pending session build from remote service.
+ *
+ *  @param[in] bus          - handle to system dbus
+ *  @param[in] slug         - the slug of service that is managing target
+ *                            session.
+ *  @param[in] username     - the owner username of the session.
+ *  @param[in] remoteIPAddr - the IP address of the session initiator.
+ *
+ *  @return int             - session build status
+ */
+extern int obmcsesCommitSessionBuildRemote(sd_bus* bus, const char* slug,
+                                            const char* username,
+                                            const char* remoteIPAddr);
+
+/**
+ * @brief Get sessions info descriptor
+ *
+ * @param[in] sessionId     - session identifier
+ * @param[out] pSessionInfo - pointer to the session info descriptor.
+ *
+ * @note The 'pSessionInfo' param memory is allocated internally. The client
+ *       takes responsibility for freed the obtained outputs.
+ *
+ * @return int              - status of retrieving session info descriptor.
+ */
+extern int obmcsesGetSessionInfo(obmcsesSessionId sessionId,
+                                    sessObmcInfoHandle* pSessionInfo);
+
+/**
+ * @brief Get sessions info descriptors list
+ *
+ * @param[out] pSessionInfoList - pointer to array of session info
+ *                                descriptors.
+ * @param[out] count            - count of retrieving array items
+ * @return int                  - status of retrieving descriptors list
+ */
+extern int obmcsesGetSessionsList(sessObmcInfoHandle* pSessionInfoList,
+                                    size_t* count);
+
+/**
+ * @brief Release the memory of the sessions info.
+ *
+ * @param[in] sessionInfoHandle - pointer to session info handle.
+ * @param[in] count             - count of array items
+ * @return int                  - freeing status of specified handle.
+ * 
+ */
+extern int obmcsesReleaseSessionHandle(sessObmcInfoHandle sessionInfoHandle);
+
+/**
+ * @brief Retrieve the session info from descriptor list by specified index
+ *
+ * @param[in] sessionInfoHandle     - pointer to array of session info
+ *                                    descriptors.
+ * @param[in] index                 - index if item to retrieve from list
+ * @param[out] pSessionInfoHandle   - index if item to retrieve from list
+ * @return int                      - errno status of obtaining session info
+ */
+extern int obmcsesGetPtrToHandle(const sessObmcInfoHandle sessionInfoHandle,
+                                 size_t index,
+                                 sessObmcInfoHandle* pSessionInfoHandle);
+
+/**
+ * @brief Get session details by session info descriptor.
+ *
+ * @param[in] handle            - session info descriptor
+ * @param[out] sessionId        - session identifier
+ * @param[out] username         - the owner username of the session.
+ * @param[out] address          - the IP address of the session initiator.
+ * @param[out] type             - the type of session
+ * @return int                  - status of retrieving session details
+ *
+ * @note Specify the `nullptr` if you don't want to retrieve some output
+ *       field.
+ */
+extern int obmcsesGetSessionDetails(const sessObmcInfoHandle handle,
+                                    obmcsesSessionId* sessionId,
+                                    char const** username, char const** address,
+                                    obmcsessType* type);
+
+/**
+ * @brief Remove a dbus session object from storage and unpublish it from
+ *        dbus.
+ *
+ * @param[in] sessionId     - unique session ID to remove from storage
+ * 
+ * @return true             - success
+ * @return false            - fail
+ */
+extern OBMCBool obmcsesRemove(obmcsesSessionId sessionId);
+
+/**
+ * @brief Remove a dbus session object from storage and unpublish it from
+ *        dbus call configured cleanup routine 
+ *
+ * @param[in] sessionId     - unique session ID to remove from storage
+ * 
+ * @return true             - success
+ * @return false            - fail
+ */
+extern OBMCBool obmcsesRemoveWithoutCleanup(obmcsesSessionId sessionId);
+
+/**
+ * @brief Remove all sessions associated with the specified user.
+ *
+ * @param userName      - username to close appropriate sessions
+ *
+ * @return std::size_t  - count of closed sessions
+ */
+extern unsigned int obmcsesRemoveAllByUser(const char* userName);
+
+/**
+ * @brief Remove all sessions which have been opened from the specified IPv4
+ *        address.
+ *
+ * @param remoteAddress - the IP address of the session initiator..
+ *
+ * @return std::size_t  - count of closed sessions
+ */
+extern unsigned int obmcsesRemoveAllByAddress(const char* remoteAddress);
+
+/**
+ * @brief Remove all sessions of specified type.
+ *
+ * @param type         - the type of session to close.
+ *
+ * @return std::size_t - count of closed sessions
+ */
+extern unsigned int obmcsesRemoveAllByType(obmcsessType type);
+
+/**
+ * @brief Unconditional removes all opened sessions.
+ *
+ * @return std::size_t - count of closed sessions
+ */
+extern unsigned int obmcsesRemoveAll();
+
+/**
+ * @brief Get transaction status of session building
+ *
+ * @return true - transaction is process
+ * @return false - transaction not started
+ */
+extern OBMCBool obmcsesIsSessionBuildPending();
+
+/**
+ * @brief Reset the active session build transaction
+ *
+ */
+extern void obmcsesResetPendginSessionBuild();
+
+/**
+ * @brief convert session identifier from string to obmcsesSessionId
+ *
+ * @param sessionId
+ * @return obmcsesSessionId
+ */
+extern obmcsesSessionId obmcsesSessionIdFromString(const char* sessionId);
+
+#if (defined __cplusplus)
+}
+#endif

--- a/include/libobmcsession/obmcsession.hpp
+++ b/include/libobmcsession/obmcsession.hpp
@@ -1,0 +1,77 @@
+
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (C) 2021 YADRO.
+ */
+
+#pragma once
+
+#include <libobmcsession/obmcsession.h>
+
+#include <libobmcsession/obmcsession_proto.hpp>
+#include <sdbusplus/bus.hpp>
+
+/** @brief Constructs session manager
+ *
+ * @param[in] bus           - Handle to system dbus
+ * @param[in] slug          - The Dbus service slug uniquely identifying the
+ *                            source of a session to create the appropriate
+ *                            items from. Service name template:
+ *                            'xyz.openbmc_project.Session.${slug}'.
+ * @param[in] type          - Type of all session items that will be created
+ * by the current instance.
+ * @return int              - session manager initialization status
+ */
+extern int obmcsesManagerInitAsio(sdbusplus::bus::bus& bus,
+                                  const std::string& slug, obmcsessType type);
+
+/**
+ * @brief Create a session and publish into the dbus without appropriate
+ *        session payload
+ *
+ * @param[in] cleanupFn             - the callback to cleanup session on
+ *                                    destroy.
+ * @param[out] SessionIdentifier    - unique session ID
+ *
+ * @note The session is incomplete. Metadata of session must be set for 10
+ *       seconds. Otherwise, the current session will be closed. All other
+ *       new session creates requests will be rejected until the current
+ *       created session accepts metadata or is removed by timeout.
+ *
+ * @return int                      - session build status
+ */
+extern int obmcsesCreateTransactionWithFCleanup(SessionCleanupFn&& cleanupFn,
+                                                obmcsesSessionId* sessionId);
+
+/**
+ * @brief Create a session and publish into the dbus with cleanup callback
+ *        on the session destroy.
+ *
+ * @param[in] userName              - the owner user name
+ * @param[in] remoteAddress         - the IP address of the session
+ *                                    initiator.
+ * @param[in] cleanupFn             - the callback to cleanup session on
+ *                                    destroy.
+ * @param[out] SessionIdentifier    - unique session ID
+ *
+ * @return int                      - session build status
+ */
+extern int obmcsesCreateWithFCleanup(const std::string& userName,
+                                     const std::string& remoteAddress,
+                                     SessionCleanupFn&& cleanupFn,
+                                     obmcsesSessionId* sessionId);
+
+/** @brief Commit pending session build from remote service.
+ *
+ *  @param[in] bus          - handle to system dbus
+ *  @param[in] slug         - the slug of service that is managing target
+ *                            session.
+ *  @param[in] username     - the owner username of the session.
+ *  @param[in] remoteIPAddr - the IP address of the session initiator.
+ *
+ *  @return int             - session build status
+ */
+extern int obmcsesCommitSessionRemoteAsio(sdbusplus::bus::bus& bus,
+                                          const std::string& slug,
+                                          const std::string& username,
+                                          const std::string& remoteIPAddr);

--- a/include/libobmcsession/obmcsession_proto.h
+++ b/include/libobmcsession/obmcsession_proto.h
@@ -1,0 +1,37 @@
+
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (C) 2021 YADRO.
+ */
+#pragma once
+
+#if (defined __cplusplus)
+extern "C"
+{
+#endif
+
+#ifndef bool
+#define OBMCBool int
+#else
+#define OBMCBool bool
+#endif
+
+typedef long unsigned int obmcsesSessionId;
+typedef OBMCBool (*obmcsesCleanupFn)(obmcsesSessionId id);
+typedef void* sessObmcInfoHandle;
+
+/** session types */
+typedef enum obmcsessType {
+    obmcsessTypeHostConsole,
+    obmcsessTypeIPMI,
+    obmcsessTypeKVMIP,
+    obmcsessTypeManagerConsole,
+    obmcsessTypeRedfish,
+    obmcsessTypeVirtualMedia,
+    obmcsessTypeWebUI,
+    obmcsessTypeNBD
+} obmcsessType;
+
+#if (defined __cplusplus)
+}
+#endif

--- a/include/libobmcsession/obmcsession_proto.hpp
+++ b/include/libobmcsession/obmcsession_proto.hpp
@@ -1,0 +1,12 @@
+
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (C) 2021 YADRO.
+ */
+#pragma once
+
+#include <functional>
+#include <libobmcsession/obmcsession_proto.h>
+
+using SessionIdentifier = std::size_t;
+using SessionCleanupFn = std::function<bool(SessionIdentifier)>;

--- a/include/libobmcsession/session.hpp
+++ b/include/libobmcsession/session.hpp
@@ -41,14 +41,14 @@ class SessionItem :
      *
      * @param[in] bus               - Handle to system dbus
      * @param[in] objPath           - The Dbus path that hosts Session Item.
-     * @param[in] managerWeakPtr    - The weakptr of manager.
+     * @param[in] managerPtr        - The pointer of manager.
      */
     SessionItem(sdbusplus::bus::bus& bus, const std::string& objPath,
-                SessionManagerWeakPtr managerWeakPtr) :
+                SessionManagerPtr managerPtr) :
         SessionItemServerObject(bus, objPath.c_str()),
         AssocDefinitionServerObject(bus, objPath.c_str()),
         DeleteServerObject(bus, objPath.c_str()), bus(bus), path(objPath),
-        managerWeakPtr(managerWeakPtr)
+        managerPtr(managerPtr)
     {
         // Nothing to do here
     }
@@ -57,17 +57,18 @@ class SessionItem :
      *
      * @param[in] bus           - Handle to system dbus
      * @param[in] objPath       - The Dbus path that hosts Session Item
+     * @param[in] managerPtr        - The pointer of manager.
      * @param[in] cleanupFn     - The callback will be handling a customized
      *                            cleanup of the session on the session-item
      *                            removal.
      */
     SessionItem(sdbusplus::bus::bus& bus, const std::string& objPath,
-                SessionManagerWeakPtr managerWeakPtr,
+                SessionManagerPtr managerPtr,
                 SessionManager::SessionCleanupFn&& cleanupFn) :
         SessionItemServerObject(bus, objPath.c_str()),
         AssocDefinitionServerObject(bus, objPath.c_str()),
         DeleteServerObject(bus, objPath.c_str()), bus(bus), path(objPath),
-        managerWeakPtr(managerWeakPtr), cleanupFn(cleanupFn)
+        managerPtr(managerPtr), cleanupFn(cleanupFn)
     {
         // Nothing to do here
     }
@@ -103,13 +104,13 @@ class SessionItem :
     void resetCleanupFn(SessionManager::SessionCleanupFn&&);
 
     /**
-     * @brief Associate user of specified UID with the current session.
+     * @brief Associate user of specified username with the current session.
      *
-     * @param userName              - the user name to associate with the
-     *                                current session.
+     * @param userName          - the user name to associate with the
+     *                            current session.
      *
-     * @throw std::exception          failure on set user object relation to
-     *                                the current session
+     * @throw std::exception    failure on set user object relation to
+     *                          the current session
      */
     void adjustSessionOwner(const std::string& userName);
 
@@ -118,7 +119,7 @@ class SessionItem :
     sdbusplus::bus::bus& bus;
     /** @brief Path of the group instance */
     const std::string path;
-    SessionManagerWeakPtr managerWeakPtr;
+    SessionManagerPtr managerPtr;
     SessionManager::SessionCleanupFn cleanupFn;
 };
 

--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,4 @@
-project('libobmcsession', 'cpp',
+project('libobmcsession', ['c','cpp'],
     default_options: [
         'warning_level=3',
         'werror=true',
@@ -9,7 +9,7 @@ project('libobmcsession', 'cpp',
 )
 pkg = import('pkgconfig')
 
-boost = dependency('boost', required: true)
+boost = dependency('boost', modules: ['coroutine', 'context'], required: true)
 threads = dependency('threads', required: true)
 sdbusplus_dep = dependency('sdbusplus', required: true)
 pdi_dep = dependency('phosphor-dbus-interfaces', required: true)
@@ -59,3 +59,26 @@ obmcsession = shared_library('obmcsession',
     install: true,
 )
 pkg.generate(obmcsession)
+
+systemd = dependency('systemd')
+systemd_system_unit_dir = systemd.get_pkgconfig_variable('systemdsystemunitdir')
+bindir = get_option('prefix') + '/' +get_option('bindir')
+
+conf_data = configuration_data()
+conf_data.set('MESON_INSTALL_PREFIX',get_option('prefix'))
+
+configure_file(input : 'obmcsess-sshsrv.service.in',
+    output : 'obmcsess-sshsrv.service',
+    install_dir: systemd_system_unit_dir,
+    configuration: conf_data,
+    install : true
+)
+
+executable('obmcses-sshsvc', 
+    ['services/sshsvc.cpp'],
+    dependencies: [boost, sdbusplus_dep, threads, pl_dep],
+    include_directories: ['include'],
+    link_with: [obmcsession],
+    install: true,
+    install_dir: bindir
+)

--- a/meson.build
+++ b/meson.build
@@ -13,6 +13,7 @@ boost = dependency('boost', required: true)
 threads = dependency('threads', required: true)
 sdbusplus_dep = dependency('sdbusplus', required: true)
 pdi_dep = dependency('phosphor-dbus-interfaces', required: true)
+pl_dep = dependency('phosphor-logging', required: true)
 
 cpp_args = [
     '-DBOOST_SYSTEM_NO_DEPRECATED',
@@ -32,11 +33,14 @@ libruntime_so_version = '@0@.@1@.@2@'.format((libruntime_lt_c - libruntime_lt_a)
                                               libruntime_lt_r)
 
 install_headers(
-    'include/libobmcsession/manager.hpp',
-    'include/libobmcsession/session.hpp',
+    'include/libobmcsession/obmcsession.h',
+    'include/libobmcsession/obmcsession.hpp',
+    'include/libobmcsession/obmcsession_proto.h',
+    'include/libobmcsession/obmcsession_proto.hpp',
     subdir: 'libobmcsession')
 
 obmcsession = shared_library('obmcsession',
+    'src/api.cpp',
     'src/manager.cpp',
     'src/session.cpp',
     cpp_args: cpp_args,
@@ -46,9 +50,11 @@ obmcsession = shared_library('obmcsession',
         threads,
         sdbusplus_dep,
         pdi_dep,
+        pl_dep,
     ],
     include_directories: [
-        'include'
+        'include',
+        'src',
     ],
     install: true,
 )

--- a/meson.build
+++ b/meson.build
@@ -10,6 +10,7 @@ project('libobmcsession', 'cpp',
 pkg = import('pkgconfig')
 
 boost = dependency('boost', required: true)
+threads = dependency('threads', required: true)
 sdbusplus_dep = dependency('sdbusplus', required: true)
 pdi_dep = dependency('phosphor-dbus-interfaces', required: true)
 
@@ -30,7 +31,10 @@ libruntime_so_version = '@0@.@1@.@2@'.format((libruntime_lt_c - libruntime_lt_a)
                                               libruntime_lt_a,
                                               libruntime_lt_r)
 
-install_headers('include/libobmcsession/manager.hpp', subdir: 'libobmcsession')
+install_headers(
+    'include/libobmcsession/manager.hpp',
+    'include/libobmcsession/session.hpp',
+    subdir: 'libobmcsession')
 
 obmcsession = shared_library('obmcsession',
     'src/manager.cpp',
@@ -39,6 +43,7 @@ obmcsession = shared_library('obmcsession',
     version : libruntime_so_version,
     dependencies: [
         boost,
+        threads,
         sdbusplus_dep,
         pdi_dep,
     ],

--- a/obmcsess-sshsrv.service.in
+++ b/obmcsess-sshsrv.service.in
@@ -1,0 +1,14 @@
+[Unit]
+Description=OpenBMC Session SSH connection watcher service
+
+Wants=dropbear.socket
+After=dropbear.socket
+
+[Service]
+ExecReload=kill -s HUP $MAINPID
+ExecStart=@MESON_INSTALL_PREFIX@/bin/obmcses-sshsvc
+Type=simple
+Restart=always
+
+[Install]
+WantedBy=dropbear.socket

--- a/services/sshsvc.cpp
+++ b/services/sshsvc.cpp
@@ -1,0 +1,209 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2021 YADRO
+
+#include <stdlib.h>
+
+#include <boost/asio.hpp>
+#include <libobmcsession/obmcsession.hpp>
+#include <sdbusplus/asio/connection.hpp>
+#include <sdbusplus/bus.hpp>
+#include <sdbusplus/bus/match.hpp>
+
+#include <phosphor-logging/log.hpp>
+
+#include <iostream>
+#include <mutex>
+
+using namespace boost::asio;
+using namespace sdbusplus::message;
+using namespace phosphor::logging;
+
+using ConnectionPtr = std::shared_ptr<sdbusplus::asio::connection>;
+using UnitInfo =
+    std::tuple<std::string, std::string, std::string, std::string, std::string,
+               std::string, object_path, uint32_t, std::string, object_path>;
+
+using ListUnitInfo = std::vector<UnitInfo>;
+
+static const auto sshUitsSessIdDict =
+    std::make_unique<std::map<SessionIdentifier, std::string>>();
+
+inline bool closeSSH(ConnectionPtr conn, const std::string& unitName);
+inline void setupNewSessionSignals(ConnectionPtr conn);
+static void asyncInitSessionList(ConnectionPtr conn, yield_context yield);
+
+inline bool closeSSH(ConnectionPtr conn, const std::string& unitName)
+{
+    std::mutex mutex;
+    std::lock_guard<std::mutex> lock(mutex);
+    for (const auto& [sessionId, storedUnit] : *sshUitsSessIdDict)
+    {
+        if (!storedUnit.empty() && storedUnit == unitName)
+        {
+            sshUitsSessIdDict->erase(sessionId);
+            break;
+        }
+    }
+    try
+    {
+        auto callClose = conn->new_method_call(
+            "org.freedesktop.systemd1", "/org/freedesktop/systemd1",
+            "org.freedesktop.systemd1.Manager", "StopUnit");
+        callClose.append(unitName, "ignore-dependencies");
+        conn->call_noreply(callClose);
+    }
+    catch (std::exception& ex)
+    {
+        log<level::ERR>("Fail to send close SSH connection.",
+                        entry("ERROR=%s", ex.what()));
+        return false;
+    }
+
+    return true;
+}
+
+inline void setupNewSessionSignals(ConnectionPtr conn)
+{
+    using namespace sdbusplus::bus::match;
+
+    static const auto newSshRule =
+        rules::type::signal() + rules::path("/org/freedesktop/systemd1") +
+        rules::interface("org.freedesktop.systemd1.Manager") +
+        rules::member("UnitNew");
+
+    static const auto delSshRule =
+        rules::type::signal() + rules::path("/org/freedesktop/systemd1") +
+        rules::interface("org.freedesktop.systemd1.Manager") +
+        rules::member("UnitRemoved");
+
+    static match newSSHWatcher(
+        *conn, newSshRule, [conn](sdbusplus::message::message& message) {
+            std::string unitName;
+            try
+            {
+                message.read(unitName);
+            }
+            catch (const std::exception& e)
+            {
+                std::cerr << "Failed to read message of UnitNew signal, PATH="
+                          << message.get_path() << ": " << e.what();
+            }
+
+            if (unitName.starts_with("dropbear@"))
+            {
+                std::cout << "New SSH connection: " << unitName << std::endl;
+                obmcsesSessionId sessionId;
+                try
+                {
+                    auto r = obmcsesCreateTransactionWithFCleanup(
+                        [conn](obmcsesSessionId id) -> OBMCBool {
+                            auto sshUnitIt = sshUitsSessIdDict->find(id);
+                            if (sshUnitIt == sshUitsSessIdDict->end())
+                            {
+                                return false;
+                            }
+                            return closeSSH(conn, sshUnitIt->second);
+                        },
+                        &sessionId);
+                    if (r)
+                    {
+                        std::cerr << "Fail to create obmcsess object: "
+                                  << std::strerror(r) << std::endl;
+                        return;
+                    }
+                    sshUitsSessIdDict->emplace(sessionId, unitName);
+                }
+                catch (std::exception& ex)
+                {
+                    std::cerr << "Failed: " << ex.what() << std::endl;
+                }
+            }
+        });
+
+    static match delSSHWatcher(
+        *conn, delSshRule, [](sdbusplus::message::message& message) {
+            std::string unitName;
+            try
+            {
+                message.read(unitName);
+            }
+            catch (const std::exception& e)
+            {
+                std::cerr
+                    << "Failed to read message of UnitRemoved signal, PATH="
+                    << message.get_path() << ": " << e.what();
+            }
+
+            if (unitName.starts_with("dropbear@"))
+            {
+                std::cout << "The SSH connection closed: " << unitName
+                          << std::endl;
+                for (const auto& [sessionId, storedUnit] : *sshUitsSessIdDict)
+                {
+                    if (unitName == storedUnit)
+                    {
+                        if (!obmcsesRemoveWithoutCleanup(sessionId))
+                        {
+                            std::cerr
+                                << "Failed to close ssh session:" << sessionId
+                                << std::endl;
+                        }
+                    }
+                }
+            }
+        });
+}
+
+static void asyncInitSessionList(ConnectionPtr conn, yield_context yield)
+{
+    boost::system::error_code ec;
+    const auto listUnits = conn->yield_method_call<ListUnitInfo>(
+        yield, ec, "org.freedesktop.systemd1", "/org/freedesktop/systemd1",
+        "org.freedesktop.systemd1.Manager", "ListUnits");
+
+    if (ec)
+    {
+        std::cerr << "Fail to call the ListUnit dbus method: " << ec.message()
+                  << std::endl;
+        return;
+    }
+    for (const UnitInfo& unitInfo : listUnits)
+    {
+        try
+        {
+            auto& unitName = std::get<0>(unitInfo);
+            if (unitName.starts_with("dropbear@"))
+            {
+                std::cout << "Found SSH session: " << unitName << std::endl;
+                closeSSH(conn, unitName);
+            }
+        }
+        catch (std::out_of_range& ex)
+        {
+            std::cerr << "Fail to retrieve the UnitName field from UnitInfo: "
+                      << ex.what() << std::endl;
+        }
+    }
+}
+
+int main()
+{
+    io_context io;
+    auto conn = std::make_shared<sdbusplus::asio::connection>(io);
+
+    int r = obmcsesManagerInitAsio(*conn, "SSH", obmcsessTypeManagerConsole);
+
+    if (r != 0)
+    {
+        return r;
+    }
+    setupNewSessionSignals(conn);
+
+    spawn(io, [conn](boost::asio::yield_context yield) {
+        asyncInitSessionList(conn, yield);
+    });
+
+    io.run();
+
+    return EXIT_SUCCESS;
+}

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -1,0 +1,662 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2021 YADRO
+
+#include <errno.h>
+#include <stdio.h>
+
+#include <phosphor-logging/elog-errors.hpp>
+#include <phosphor-logging/log.hpp>
+
+#include <libobmcsession/obmcsession.hpp>
+#include <manager.hpp>
+#include <session.hpp>
+
+#include <iostream>
+
+using namespace obmc::session;
+using namespace phosphor::logging;
+
+static SessionManagerPtr managerPtr;
+
+/** The session info public struct descriptor */
+typedef struct
+{
+    obmcsesSessionId id;
+    char username[64];
+    char address[24];
+    obmcsessType type;
+} __attribute__((aligned(1))) SessionInfo;
+
+/**
+ * @brief Copy data from internal session info to session info descriptor.
+ *
+ * @param internalSessionInfo   - the internal session info
+ * @param sessionInfo           - the session info public descriptor
+ *
+ * @return int                  - errno status
+ */
+inline int copySessionInfo(
+    const SessionManager::InternalSessionInfo& internalSessionInfo,
+    SessionInfo* sessionInfo);
+
+int obmcsesManagerInit(sd_bus* bus, const char* slug, obmcsessType type)
+{
+    if (managerPtr)
+    {
+        return EEXIST;
+    }
+    if (!bus)
+    {
+        return EINVAL;
+    }
+    try
+    {
+        managerPtr = std::make_shared<SessionManager>(
+            sdbusplus::bus::bus(bus), slug,
+            static_cast<SessionManager::SessionType>(type));
+    }
+    catch (...)
+    {
+        return ENOMEM;
+    }
+    return 0;
+}
+
+int obmcsesManagerInitAsio(sdbusplus::bus::bus& bus, const std::string& slug,
+                           obmcsessType type)
+{
+    try
+    {
+        managerPtr = std::make_shared<SessionManager>(
+            bus, slug, static_cast<SessionManager::SessionType>(type));
+    }
+    catch (...)
+    {
+        return ENOMEM;
+    }
+    return 0;
+}
+
+void obmcsesManagerClose()
+{
+    if (managerPtr)
+    {
+        managerPtr.reset();
+    }
+}
+
+int obmcsesCreate(const char* userName, const char* remoteAddress,
+                  obmcsesSessionId* sessionId)
+{
+    if (!userName || !sessionId)
+    {
+        return EINVAL;
+    }
+    if (!managerPtr)
+    {
+        return ENOENT;
+    }
+    try
+    {
+        *sessionId = managerPtr->create(userName, remoteAddress);
+    }
+    catch (...)
+    {
+        return EPERM;
+    }
+    return 0;
+}
+
+int obmcsesCreateTransaction(obmcsesSessionId* sessionId)
+{
+    if (!sessionId)
+    {
+        return EINVAL;
+    }
+    if (!managerPtr)
+    {
+        return ENOENT;
+    }
+    try
+    {
+        *sessionId = managerPtr->startTransaction();
+    }
+    catch (...)
+    {
+        managerPtr->resetPendginSessionBuild();
+        return EPERM;
+    }
+    return 0;
+}
+
+int obmcsesCreateTransactionWithCleanup(obmcsesCleanupFn cleanupFn,
+                                        obmcsesSessionId* sessionId)
+{
+    log<level::DEBUG>(
+        "Call to start a new session build transaction (c-proxy)");
+
+    if (!sessionId || !cleanupFn)
+    {
+        log<level::ERR>("Fail to start a new session build transaction "
+                        "(c-proxy): invalid argument");
+        return EINVAL;
+    }
+    if (!managerPtr)
+    {
+        log<level::ERR>(
+            "Fail to start a new session build transaction (c-proxy): "
+            "manager not initialized");
+        return ENOENT;
+    }
+    try
+    {
+        *sessionId = managerPtr->startTransaction(
+            [cleanupFn](SessionIdentifier id) -> bool {
+                return cleanupFn(id);
+            });
+    }
+    catch (const std::exception& ex)
+    {
+        log<level::ERR>(
+            "Fail to start a new session build transaction (c-proxy)",
+            entry("ERROR=%s", ex.what()));
+        managerPtr->resetPendginSessionBuild();
+        return EPERM;
+    }
+
+    log<level::INFO>(
+        "Start a new session build transaction (c-proxy): success");
+    return 0;
+}
+
+int obmcsesCreateTransactionWithFCleanup(SessionCleanupFn&& cleanupFn,
+                                         obmcsesSessionId* sessionId)
+{
+
+    log<level::DEBUG>(
+        "Call to start a new session build transaction");
+    if (!sessionId || !cleanupFn)
+    {
+        log<level::ERR>(
+            "Fail to start a new session build transaction: invalid argument");
+        return EINVAL;
+    }
+    if (!managerPtr)
+    {
+        log<level::ERR>("Fail to start a new session build transaction: "
+                        "manager not initialized");
+        return ENOENT;
+    }
+    try
+    {
+        *sessionId = managerPtr->startTransaction(
+            std::forward<SessionCleanupFn>(cleanupFn));
+    }
+    catch (std::exception& ex)
+    {
+        log<level::ERR>("Fail to start a new session build transaction",
+                        entry("ERROR=%s", ex.what()));
+        managerPtr->resetPendginSessionBuild();
+        return EPERM;
+    }
+
+    log<level::INFO>("Start a new session build transaction: success");
+    return 0;
+}
+
+int obmcsesCreateWithCleanup(const char* userName, const char* remoteAddress,
+                             obmcsesCleanupFn cleanupFn,
+                             obmcsesSessionId* sessionId)
+{
+    if (!sessionId || !userName || !cleanupFn)
+    {
+        return EINVAL;
+    }
+    if (!managerPtr)
+    {
+        return ENOENT;
+    }
+    try
+    {
+        *sessionId = managerPtr->create(
+            userName, remoteAddress, [cleanupFn](SessionIdentifier id) -> bool {
+                return cleanupFn(id);
+            });
+    }
+    catch (...)
+    {
+        return EPERM;
+    }
+
+    return 0;
+}
+
+int obmcsesCreateWithFCleanup(const std::string& userName,
+                              const std::string& remoteAddress,
+                              SessionCleanupFn&& cleanupFn,
+                              obmcsesSessionId* sessionId)
+{
+    if (!cleanupFn)
+    {
+        return EINVAL;
+    }
+    if (!managerPtr)
+    {
+        return ENOENT;
+    }
+    try
+    {
+        *sessionId = managerPtr->create(
+            userName, remoteAddress, std::forward<SessionCleanupFn>(cleanupFn));
+    }
+    catch (...)
+    {
+        return EPERM;
+    }
+
+    return 0;
+}
+
+int obmcsesCommitSessionBuild(const char* username, const char* remoteIPAddr)
+{
+    log<level::DEBUG>("Finalize a new session build transaction.");
+    if (!username || !remoteIPAddr)
+    {
+        log<level::ERR>("Fail to commit a session build transaction. An "
+                        "invalid argument has been specified.",
+                        entry("ARGSPTR=(%p, %p, %p)", username));
+        return EINVAL;
+    }
+    if (!managerPtr)
+    {
+        log<level::ERR>("Fail to commit a new session build transaction: "
+                        "manager not initialized");
+        return ENOENT;
+    }
+    try
+    {
+        managerPtr->commitSessionBuild(username, remoteIPAddr);
+    }
+    catch (const std::exception& ex)
+    {
+        managerPtr->resetPendginSessionBuild();
+        log<level::ERR>(
+            "Fail to commit a session build transaction (remotelly)",
+            entry("ERRMSG=%s", ex.what()));
+        return EPERM;
+    }
+
+    log<level::INFO>(
+        "Successful to finalize a new session build transaction.",
+        entry("USERNAME=%s", username), entry("REMOTEIP=%s", remoteIPAddr));
+
+    return 0;
+}
+
+int obmcsesCommitSessionBuildRemote(sd_bus* bus, const char* slug,
+                                    const char* username,
+                                    const char* remoteIPAddr)
+{
+    log<level::DEBUG>(
+        "Finalize a new session build transaction (remotelly, c-proxy).");
+    if (!bus || !slug || !username || !remoteIPAddr)
+    {
+        log<level::ERR>("Fail to commit a session build transaction "
+                        "(remotelly, c-proxy). Specified an invalid argument.",
+                        entry("ARGSPTR=(%p, %p, %p, %p)", bus, slug, username,
+                              remoteIPAddr));
+        return EINVAL;
+    }
+
+    try
+    {
+        sdbusplus::bus::bus localDbus(bus);
+        SessionManager::commitSessionBuild(localDbus, slug, username,
+                                           remoteIPAddr);
+        localDbus.release();
+    }
+    catch (const std::exception& ex)
+    {
+        log<level::ERR>(
+            "Fail to commit a session build transaction (remotelly, c-proxy)",
+            entry("ERRMSG=%s", ex.what()));
+        return EPERM;
+    }
+
+    log<level::INFO>(
+        "Successfully created new session via remote commit of session build "
+        "transaction (remotelly, c-proxy).",
+        entry("SVCSLUG=%s", slug), entry("USERNAME=%s", username),
+        entry("REMOTEIP=%s", remoteIPAddr));
+    return 0;
+}
+
+int obmcsesCommitSessionRemoteAsio(sdbusplus::bus::bus& bus,
+                                   const std::string& slug,
+                                   const std::string& username,
+                                   const std::string& remoteIPAddr)
+{
+    log<level::DEBUG>("Finalize a new session build transaction (remotelly).");
+    try
+    {
+        SessionManager::commitSessionBuild(bus, slug, username, remoteIPAddr);
+    }
+    catch (const std::exception& ex)
+    {
+        log<level::ERR>(
+            "Fail to commit a session build transaction (remotelly, c-proxy)",
+            entry("ERRMSG=%s", ex.what()));
+        return EPERM;
+    }
+
+    log<level::INFO>(
+        "Successfully created new session via remote commit of session build "
+        "transaction (remotelly).",
+        entry("SVCSLUG=%s", slug.c_str()), entry("USERNAME=%s", username.c_str()),
+        entry("REMOTEIP=%s", remoteIPAddr.c_str()));
+    return 0;
+}
+
+int obmcsesGetPtrToHandle(const sessObmcInfoHandle sessionInfoHandle,
+                          size_t index, sessObmcInfoHandle* pSessionInfoHandle)
+{
+    if (!sessionInfoHandle || !pSessionInfoHandle)
+    {
+        return EINVAL;
+    }
+
+    auto* sessionList = reinterpret_cast<SessionInfo*>(sessionInfoHandle);
+    if (!sessionList)
+    {
+        return EINVAL;
+    }
+
+    *pSessionInfoHandle =
+        reinterpret_cast<sessObmcInfoHandle>(&(sessionList[index]));
+
+    return 0;
+}
+
+int obmcsesGetSessionDetails(const sessObmcInfoHandle handle,
+                             obmcsesSessionId* sessionId, const char** username,
+                             const char** address, obmcsessType* type)
+{
+    if (!handle)
+    {
+        return EINVAL;
+    }
+    if (!managerPtr)
+    {
+        return ENOENT;
+    }
+    try
+    {
+        const auto* info = reinterpret_cast<const SessionInfo*>(handle);
+
+        if (!info)
+        {
+            return EINVAL;
+        }
+        if (sessionId)
+        {
+            *sessionId = info->id;
+        }
+        if (username)
+        {
+            *username = info->username;
+        }
+        if (address)
+        {
+            *address = info->address;
+        }
+        if (type)
+        {
+            *type = static_cast<obmcsessType>(info->type);
+        }
+    }
+    catch (...)
+    {
+        return EPERM;
+    }
+    return 0;
+}
+
+inline int copySessionInfo(
+    const SessionManager::InternalSessionInfo& internalSessionInfo,
+    SessionInfo* sessionInfo)
+{
+    if (!sessionInfo)
+    {
+        return EINVAL;
+    }
+    sessionInfo->id = internalSessionInfo.id;
+    sessionInfo->type = static_cast<obmcsessType>(internalSessionInfo.type);
+    strcpy(sessionInfo->username, internalSessionInfo.username.c_str());
+    strcpy(sessionInfo->address, internalSessionInfo.remoteAddress.c_str());
+    return 0;
+}
+
+int obmcsesGetSessionInfo(obmcsesSessionId sessionId,
+                          sessObmcInfoHandle* pSessionInfo)
+{
+    if (!pSessionInfo)
+    {
+        return EINVAL;
+    }
+    if (!managerPtr)
+    {
+        return ENOENT;
+    }
+    try
+    {
+        SessionManager::InternalSessionInfo internalSessionInfo;
+        SessionInfo* sessionInfo;
+        managerPtr->getSessionInfo(sessionId, internalSessionInfo);
+        sessionInfo =
+            reinterpret_cast<SessionInfo*>(malloc(sizeof(SessionInfo)));
+        memset(sessionInfo, 0, sizeof(sessionInfo));
+        if (!sessionInfo ||
+            (0 != copySessionInfo(internalSessionInfo, sessionInfo)))
+        {
+            return ENOMEM;
+        }
+
+        *pSessionInfo = sessionInfo;
+    }
+    catch (...)
+    {
+        return EPERM;
+    }
+    return 0;
+}
+
+int obmcsesGetSessionsList(sessObmcInfoHandle* sessionInfoList, size_t* count)
+{
+    if (!sessionInfoList || !count)
+    {
+        return EINVAL;
+    }
+    if (!managerPtr)
+    {
+        return ENOENT;
+    }
+    try
+    {
+        SessionManager::InternalSessionInfoList sessionsList;
+        managerPtr->getAllSessions(sessionsList);
+        *count = sessionsList.size();
+        auto* internalList = reinterpret_cast<SessionInfo*>(
+            malloc((*count) * sizeof(SessionInfo)));
+        memset(internalList, 0, (*count) * sizeof(SessionInfo));
+        if (!internalList)
+        {
+            return ENOMEM;
+        }
+        size_t index = 0;
+        for (auto it : sessionsList)
+        {
+            auto* internalInfo = internalList + index;
+            if (0 != copySessionInfo(it.second, &(*internalInfo)))
+            {
+                continue;
+            }
+            index++;
+        }
+        *sessionInfoList = reinterpret_cast<sessObmcInfoHandle>(internalList);
+    }
+    catch (std::exception& e)
+    {
+        log<level::ERR>("Fail to obtaining an sessions list.",
+                        entry("ERROR=%s", e.what()));
+        return EPERM;
+    }
+    return 0;
+}
+
+int obmcsesReleaseSessionHandle(sessObmcInfoHandle sessionInfoHandle)
+{
+    if (!sessionInfoHandle)
+    {
+        return EINVAL;
+    }
+
+    free(sessionInfoHandle);
+
+    return 0;
+}
+
+OBMCBool obmcsesRemove(obmcsesSessionId sessionId)
+{
+    if (!managerPtr)
+    {
+        return false;
+    }
+
+    try
+    {
+        return managerPtr->remove(sessionId);
+    }
+    catch (const std::exception&)
+    {}
+
+    return false;
+}
+
+OBMCBool obmcsesRemoveWithoutCleanup(obmcsesSessionId sessionId)
+{
+    if (!managerPtr)
+    {
+        return false;
+    }
+
+    try
+    {
+        return managerPtr->remove(sessionId, false);
+    }
+    catch (const std::exception&)
+    {}
+
+    return false;
+}
+
+unsigned int obmcsesRemoveAllByUser(const char* userName)
+{
+    if (!managerPtr)
+    {
+        return 0U;
+    }
+    try
+    {
+        return managerPtr->removeAll(userName);
+    }
+    catch (const std::exception&)
+    {}
+    return 0U;
+}
+
+unsigned int obmcsesRemoveAllByAddress(const char* remoteAddress)
+{
+    if (!managerPtr)
+    {
+        return 0U;
+    }
+    try
+    {
+        return managerPtr->removeAllByRemoteAddress(remoteAddress);
+    }
+    catch (const std::exception&)
+    {}
+    return 0U;
+}
+
+unsigned int obmcsesRemoveAllByType(obmcsessType type)
+{
+    if (!managerPtr)
+    {
+        return 0U;
+    }
+    try
+    {
+        return managerPtr->removeAll(
+            static_cast<SessionManager::SessionType>(type));
+    }
+    catch (const std::exception&)
+    {}
+    return 0U;
+}
+
+unsigned int obmcsesRemoveAll()
+{
+    if (!managerPtr)
+    {
+        return 0U;
+    }
+    try
+    {
+        return managerPtr->removeAll();
+    }
+    catch (const std::exception&)
+    {}
+    return 0U;
+}
+
+OBMCBool obmcsesIsSessionBuildPending()
+{
+    if (!managerPtr)
+    {
+        return false;
+    }
+    try
+    {
+        return managerPtr->isSessionBuildPending();
+    }
+    catch (const std::exception&)
+    {}
+    return false;
+}
+
+void obmcsesResetPendginSessionBuild()
+{
+    if (!managerPtr)
+    {
+        return;
+    }
+    try
+    {
+        managerPtr->resetPendginSessionBuild();
+    }
+    catch (const std::exception&)
+    {}
+}
+
+obmcsesSessionId obmcsesSessionIdFromString(const char* sessionId)
+{
+    try
+    {
+        return SessionManager::parseSessionId(sessionId);
+    }
+    catch (...)
+    {
+        return 0;
+    }
+}

--- a/src/dbus.hpp
+++ b/src/dbus.hpp
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2021 YADRO
+
+#pragma once
+
+#include <sdbusplus/bus.hpp>
+
+#include <xyz/openbmc_project/Common/error.hpp>
+
+using InvalidArgument =
+    sdbusplus::xyz::openbmc_project::Common::Error::InvalidArgument;
+using NotAllowed =
+    sdbusplus::xyz::openbmc_project::Common::Error::NotAllowed;
+using InternalFailure =
+    sdbusplus::xyz::openbmc_project::Common::Error::InternalFailure;
+
+namespace obmc
+{
+namespace dbus
+{
+
+namespace object_mapper
+{
+constexpr const char* service = "xyz.openbmc_project.ObjectMapper";
+constexpr const char* interface = "xyz.openbmc_project.ObjectMapper";
+constexpr const char* object = "/xyz/openbmc_project/object_mapper";
+
+constexpr const char* getObject = "GetObject";
+constexpr const char* getSubTree = "GetSubTree";
+constexpr const char* getSubTreePaths = "GetSubTreePaths";
+} // namespace object_mapper
+namespace freedesktop
+{
+constexpr const char* propertyIface = "org.freedesktop.DBus.Properties";
+constexpr const char* objectManagerIface = "org.freedesktop.DBus.ObjectManager";
+
+constexpr const char* get = "Get";
+constexpr const char* getAll = "GetAll";
+constexpr const char* getManagedObjects = "GetManagedObjects";
+
+using DbusVariantType =
+    std::variant<std::vector<std::tuple<std::string, std::string, std::string>>,
+                 std::vector<std::string>, std::vector<double>, std::string,
+                 int64_t, uint64_t, double, int32_t, uint32_t, int16_t,
+                 uint16_t, uint8_t, bool>;
+
+using DBusPropertiesMap = std::map<std::string, DbusVariantType>;
+using DBusInteracesMap = std::map<std::string, DBusPropertiesMap>;
+using ManagedObjectType =
+    std::vector<std::pair<sdbusplus::message::object_path, DBusInteracesMap>>;
+
+} // namespace freedesktop
+
+using DBusGetObjectOut = std::map<std::string, std::vector<std::string>>;
+using DBusSubTreeOut = std::map<std::string, DBusGetObjectOut>;
+using UserAssociation = std::tuple<std::string, std::string, std::string>;
+using UserAssociationList = std::vector<UserAssociation>;
+using DBusSessionDetailsMap =
+    std::map<std::string,
+             std::variant<std::string, uint32_t, UserAssociationList>>;
+
+namespace utils
+{
+/**
+ * @brief Retrieve the last segment of dbus object path
+ * 
+ * @param[in] objectPath        - The DBus object path to retrieve the last segment
+ * @return const std::string    - The last segment of dbus object path
+ */
+static const std::string
+    getLastSegmentFromObjectPath(const std::string& objectPath)
+{
+    std::size_t pos = objectPath.find_last_of("/");
+    if (pos == std::string::npos)
+    {
+        throw std::logic_error("Invalid format of dbus object path.");
+    }
+    return objectPath.substr(pos + 1);
+}
+} // namespace utils
+} // namespace dbus
+} // namespace obmc

--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -1,49 +1,73 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (C) 2021 YADRO
 
-#include <libobmcsession/manager.hpp>
-#include <libobmcsession/session.hpp>
+#include <dbus.hpp>
+#include <manager.hpp>
+#include <session.hpp>
+
 #include <sdbusplus/server/object.hpp>
-#include <xyz/openbmc_project/Object/Delete/client.hpp>
-#include <xyz/openbmc_project/Session/Item/client.hpp>
+#include <xyz/openbmc_project/Association/client.hpp>
 #include <xyz/openbmc_project/Session/Build/client.hpp>
+#include <xyz/openbmc_project/Session/Item/client.hpp>
+
+#include <phosphor-logging/elog-errors.hpp>
+#include <phosphor-logging/log.hpp>
+
+#include <sdbusplus/asio/connection.hpp>
 
 #include <chrono>
 #include <iomanip>
 #include <iostream>
+#include <set>
 #include <sstream>
 
 namespace obmc
 {
+
 namespace session
 {
 
-SessionManager::SessionManager(sdbusplus::bus::bus& bus,
+using namespace obmc::dbus;
+using namespace phosphor::logging;
+
+SessionManager::SessionManager(sdbusplus::bus::bus& busIn,
                                const std::string& slug,
                                const SessionType type) :
-    SessionBuildServer(bus, sessionManagerObjectPath),
-    bus(bus), slug(slug), serviceName(serviceNameStartSegment + slug),
+    SessionBuildServer(busIn, sessionManagerObjectPath),
+    bus(&busIn), slug(slug), serviceName(serviceNameStartSegment + slug),
     type(type), pendingSessionBuild(false)
 {
     dbusManager = std::make_unique<sdbusplus::server::manager::manager>(
-        bus, sessionManagerObjectPath);
-    bus.request_name(serviceName.c_str());
+        *bus, sessionManagerObjectPath);
+    bus->request_name(serviceName.c_str());
 }
 
-SessionManager::SessionIdentifier
-    SessionManager::create(const std::string& userName,
-                           const uint32_t remoteAddress)
+SessionManager::SessionManager(sdbusplus::bus::bus&& initBus,
+                               const std::string& slug,
+                               const SessionType type) :
+    SessionBuildServer(initBus, sessionManagerObjectPath),
+    slug(slug), serviceName(serviceNameStartSegment + slug), type(type),
+    pendingSessionBuild(false), bus(std::make_unique<sdbusplus::bus::bus>(
+                                    std::forward<sdbusplus::bus::bus>(initBus)))
+{
+    dbusManager = std::make_unique<sdbusplus::server::manager::manager>(
+        initBus, sessionManagerObjectPath);
+    bus->request_name(serviceName.c_str());
+}
+
+SessionIdentifier SessionManager::create(const std::string& userName,
+                                         const std::string& remoteAddress)
 {
     if (isSessionBuildPending())
     {
-        throw std::logic_error(
-            "Pending a session creation finish. Building a new session is locked.");
+        throw std::logic_error("Pending a session creation finish. Building a "
+                               "new session is locked.");
     }
 
     auto sessionId = generateSessionId();
 
     auto sessionObjectPath = getSessionObjectPath(sessionId);
-    auto session = std::make_unique<SessionItem>(bus, sessionObjectPath,
+    auto session = std::make_shared<SessionItem>(*bus, sessionObjectPath,
                                                  shared_from_this());
 
     session->sessionID(hexSessionId(sessionId));
@@ -52,61 +76,100 @@ SessionManager::SessionIdentifier
 
     if (!userName.empty())
     {
-        session->adjustSessionOwner(userName);
+        try
+        {
+            session->adjustSessionOwner(userName);
+        }
+        catch (const std::exception& ex)
+        {
+            log<level::DEBUG>(
+                "Skip publishing the obmcsess object if user not found",
+                entry("USER=%d", userName.c_str()),
+                entry("ERROR=%s", ex.what()));
+            return 0U;
+        }
     }
 
-    sessionItems.insert_or_assign(sessionId, std::move(session));
-
+    sessionItems.emplace(sessionId, session);
     return sessionId;
 }
 
-SessionManager::SessionIdentifier
-    SessionManager::create(const std::string& userName,
-                           const uint32_t remoteAddress,
-                           SessionCleanupFn&& cleanupFn)
+SessionIdentifier SessionManager::create(const std::string& userName,
+                                         const std::string& remoteAddress,
+                                         SessionCleanupFn&& cleanupFn)
 {
     auto sessionId = this->create(userName, remoteAddress);
+    if (sessionId == 0U)
+    {
+        // session not created. Skip.
+        return sessionId;
+    }
     sessionItems.at(sessionId)->resetCleanupFn(
         std::forward<SessionCleanupFn>(cleanupFn));
     return sessionId;
 }
 
-SessionManager::SessionIdentifier SessionManager::create()
+SessionIdentifier SessionManager::startTransaction()
 {
-    auto sessionId = this->create("", 0);
+    cvTransaction.notify_all();
+    auto sessionId = this->create("", "0.0.0.0");
     sessionBuildTimerStart(sessionId);
     return sessionId;
 }
 
-SessionManager::SessionIdentifier
-    SessionManager::create(SessionCleanupFn&& cleanupFn)
+SessionIdentifier SessionManager::startTransaction(SessionCleanupFn&& cleanupFn)
 {
-    auto sessionId = this->create();
+    auto sessionId = this->startTransaction();
     sessionItems.at(sessionId)->resetCleanupFn(
         std::forward<SessionCleanupFn>(cleanupFn));
     return sessionId;
 }
 
 void SessionManager::commitSessionBuild(std::string username,
-                            uint32_t remoteIPAddr)
+                                        std::string remoteIPAddr)
 {
     if (!isSessionBuildPending())
     {
-        return;
+        log<level::ERR>(
+            "Failure to commit sesion build: transaction not started.");
+        throw InternalFailure();
     }
-    SessionItemDict::iterator sessionIt = sessionItems.find(this->pendingSessionId);
+    SessionItemDict::iterator sessionIt =
+        sessionItems.find(this->pendingSessionId);
     if (sessionIt == sessionItems.end())
     {
-        return;
+        log<level::ERR>(
+            "Failure to commit sesion build: session ID not found.",
+            entry("SESSIONID=%d", this->pendingSessionId));
+        throw InvalidArgument();
     }
-
-    sessionIt->second->setSessionMetadata(username, remoteIPAddr);
+    try
+    {
+        sessionIt->second->setSessionMetadata(username, remoteIPAddr);
+    }
+    catch (const UnknownUser& ex)
+    {
+        log<level::INFO>("User is not managed by UserManager service. Skip "
+                         "publishing a session.",
+                         entry("USER=%s", username.c_str()),
+                         entry("ERROR=%s", ex.what()));
+        // remove obmcsess object if user not found.
+        remove(sessionIt->first, false, true);
+    }
+    catch (const std::exception& ex)
+    {
+        // Keep session object to give a chance to commit session with a valid
+        // metadata in a next having time.
+        log<level::ERR>("Failure to commit sesion build.",
+                          entry("ERROR=%s", ex.what()));
+        throw InternalFailure();
+    }
     sessionBuildSucess();
 }
 
 void SessionManager::commitSessionBuild(sdbusplus::bus::bus& bus,
                                         std::string slug, std::string username,
-                                        uint32_t remoteIPAddr)
+                                        std::string remoteIPAddr)
 {
     auto serviceName = serviceNameStartSegment + slug;
     auto callMethod = bus.new_method_call(
@@ -117,139 +180,134 @@ void SessionManager::commitSessionBuild(sdbusplus::bus::bus& bus,
     bus.call_noreply(callMethod);
 }
 
-bool SessionManager::remove(SessionIdentifier sessionId)
+bool SessionManager::remove(SessionIdentifier sessionId, bool withCleanup,
+                            bool localLookup)
 {
+    log<level::DEBUG>("SessionManager::remove()", entry("SESSID=%d", sessionId),
+                      entry("CLEANUP=%d", withCleanup),
+                      entry("ISLOCAL=%d", localLookup));
     auto sessionIt = sessionItems.find(sessionId);
-    if (sessionItems.end() == sessionIt)
+    if (sessionItems.end() != sessionIt)
     {
+        auto sessionItem = sessionIt->second;
+        if (!withCleanup)
+        {
+            sessionItem->resetCleanupFn(nullptr);
+        }
+        sessionItems.erase(sessionIt);
+        return true;
+    }
+    if (localLookup) 
+    {
+        // lookup only at the current session manager (local)
+        log<level::DEBUG>("[SessionManager::remove] lookup only at current "
+                          "session manager (local)");
         return false;
     }
-    sessionItems.extract(sessionIt);
-    return true;
+    InternalSessionInfoList sessionList;
+    getAllSessions(sessionList);
+    for (const auto& [sessionInfoId, sessionInfo] : sessionList)
+    {
+        if (sessionInfoId == sessionId)
+        {
+            callCloseSession(sessionInfo.serviceName, sessionInfo.objectPath,
+                             withCleanup);
+            return true;
+        }
+    }
+    log<level::WARNING>(
+        "SessionManager::remove() fail: target session not found",
+        entry("SESSID=%s"));
+    return false;
 }
 
-std::size_t SessionManager::removeAll(const std::string& userName) const
+std::size_t SessionManager::removeAll(const std::string& userName)
 {
-    auto objects = findSessionItemObjects();
-    auto userObjectPath = "/xyz/openbmc_project/user/" + userName;
-    size_t handledSessions = 0;
-    for (const auto& [sessionObjectPath, objectMetaDict] : objects)
-    {
-        if (objectMetaDict.empty())
-        {
-            continue;
-        }
-        const auto& serviceName = objectMetaDict.begin()->first;
-        auto details = getSessionDetails(serviceName, sessionObjectPath);
-        for (const auto& [propertyName, propertyValue] : details)
-        {
-            if (propertyName == "Associations")
-            {
-                const UserAssociationList* userAssociations =
-                    std::get_if<UserAssociationList>(&propertyValue);
-                if (userAssociations == nullptr)
-                {
-                    continue;
-                }
+    std::size_t handledSessions = 0;
 
-                for (const auto& userAssociation : *userAssociations)
-                {
-                    if (std::get<0>(userAssociation) == "user" &&
-                        std::get<2>(userAssociation) == userObjectPath)
-                    {
-                        try
-                        {
-                            callCloseSession(serviceName, sessionObjectPath);
-                            handledSessions++;
-                        }
-                        catch (const std::exception&)
-                        {}
-                    }
-                }
-            }
+    for (const auto [sessionId, sessionItem] : sessionItems)
+    {
+        if (userName == sessionItem->getOwner())
+        {
+            sessionItems.erase(sessionId);
+            handledSessions++;
+        }
+    }
+
+    InternalSessionInfoList sessionList;
+    getAllSessions(sessionList);
+    for (const auto& [sessionInfoId, sessionInfo] : sessionList)
+    {
+        if (userName == sessionInfo.serviceName)
+        {
+            callCloseSession(sessionInfo.serviceName, sessionInfo.objectPath);
+            handledSessions++;
         }
     }
 
     return handledSessions;
 }
 
-std::size_t SessionManager::removeAll(uint32_t remoteAddress) const
+std::size_t
+    SessionManager::removeAllByRemoteAddress(const std::string& remoteAddress)
 {
-    auto objects = findSessionItemObjects();
-    size_t handledSessions = 0;
-    for (const auto& [sessionObjectPath, objectMetaDict] : objects)
+    std::size_t handledSessions = 0;
+
+    for (const auto [sessionId, sessionItem] : sessionItems)
     {
-        if (objectMetaDict.empty())
+        if (remoteAddress == sessionItem->remoteIPAddr())
         {
-            continue;
+            sessionItems.erase(sessionId);
+            handledSessions++;
         }
-        const auto& serviceName = objectMetaDict.begin()->first;
-        auto details = getSessionDetails(serviceName, sessionObjectPath);
-        for (const auto& [propertyName, propertyValue] : details)
+    }
+
+    InternalSessionInfoList sessionList;
+    getAllSessions(sessionList);
+    for (const auto& [sessionInfoId, sessionInfo] : sessionList)
+    {
+        if (remoteAddress == sessionInfo.remoteAddress)
         {
-            if (propertyName == "RemoteIPAddr")
-            {
-                const uint32_t* remoteAddressValue =
-                    std::get_if<uint32_t>(&propertyValue);
-                if (remoteAddressValue != nullptr &&
-                    *remoteAddressValue == remoteAddress)
-                {
-                    try
-                    {
-                        callCloseSession(serviceName, sessionObjectPath);
-                        handledSessions++;
-                    }
-                    catch (const std::exception&)
-                    {}
-                }
-            }
+            callCloseSession(sessionInfo.serviceName, sessionInfo.objectPath);
+            handledSessions++;
         }
     }
 
     return handledSessions;
 }
 
-std::size_t SessionManager::removeAll(SessionType type) const
+std::size_t SessionManager::removeAll(SessionType type)
 {
-    auto objects = findSessionItemObjects();
-    size_t handledSessions = 0;
-    for (const auto& [sessionObjectPath, objectMetaDict] : objects)
+    std::size_t handledSessions = 0;
+
+    for (const auto [sessionId, sessionItem] : sessionItems)
     {
-        if (objectMetaDict.empty())
+        if (type == sessionItem->sessionType())
         {
-            continue;
+            sessionItems.erase(sessionId);
+            handledSessions++;
         }
-        const auto& serviceName = objectMetaDict.begin()->first;
-        auto details = getSessionDetails(serviceName, sessionObjectPath);
-        for (const auto& [propertyName, propertyValue] : details)
+    }
+
+    InternalSessionInfoList sessionList;
+    getAllSessions(sessionList);
+    for (const auto& [sessionInfoId, sessionInfo] : sessionList)
+    {
+        if (type == sessionInfo.type)
         {
-            if (propertyName == "SessionType")
-            {
-                const std::string* sessionTypeValue =
-                    std::get_if<std::string>(&propertyValue);
-                if (sessionTypeValue != nullptr &&
-                    *sessionTypeValue ==
-                        sdbusplus::message::details::convert_to_string(type))
-                {
-                    try
-                    {
-                        callCloseSession(serviceName, sessionObjectPath);
-                        handledSessions++;
-                    }
-                    catch (const std::exception&)
-                    {}
-                }
-            }
+            callCloseSession(sessionInfo.serviceName, sessionInfo.objectPath);
+            handledSessions++;
         }
     }
 
     return handledSessions;
 }
 
-std::size_t SessionManager::removeAll() const
+std::size_t SessionManager::removeAll()
 {
+    size_t handledSessions = sessionItems.size();
+    sessionItems.clear();
     auto objects = findSessionItemObjects();
-    size_t handledSessions = 0;
     for (const auto& [sessionObjectPath, objectMetaDict] : objects)
     {
         if (objectMetaDict.empty())
@@ -261,8 +319,12 @@ std::size_t SessionManager::removeAll() const
             callCloseSession(objectMetaDict.begin()->first, sessionObjectPath);
             handledSessions++;
         }
-        catch (const std::exception&)
-        {}
+        catch (const std::exception& ex)
+        {
+            log<level::ERR>("Fail to remove session.",
+                            entry("OBJPATH=%s", sessionObjectPath.c_str()),
+                            entry("ERROR=%s", ex.what()));
+        }
     }
     return handledSessions;
 }
@@ -272,20 +334,30 @@ bool SessionManager::isSessionBuildPending() const
     return pendingSessionBuild;
 }
 
-void SessionManager::resetPendginSessilBuild()
+void SessionManager::resetPendginSessionBuild()
 {
     this->pendingSessionBuild = false;
     this->pendingSessionId = 0;
+    cvTransaction.notify_all();
 }
 
-SessionManager::SessionIdentifier SessionManager::generateSessionId() const
+SessionIdentifier SessionManager::generateSessionId() const
 {
     auto time = std::chrono::high_resolution_clock::now();
     std::size_t timeHash =
         std::hash<int64_t>{}(time.time_since_epoch().count());
     std::size_t serviceNameHash = std::hash<std::string>{}(serviceName);
 
-    return timeHash ^ (serviceNameHash << 1);
+    // constexpr unsigned int leftShiftSize = 8 * sizeof(std::size_t);
+    std::size_t result = timeHash ^ (serviceNameHash << 1);
+    if (result == 0U)
+    {
+        // The hash-collision guard. The Session ID == 0U is reserved and can't
+        // be provided as a valid ID.
+        return generateSessionId();
+    }
+
+    return result;
 }
 
 const std::string
@@ -307,69 +379,170 @@ const std::string SessionManager::hexSessionId(SessionIdentifier sessionId)
     return stream.str();
 }
 
-SessionManager::SessionIdentifier
-    SessionManager::parseSessionId(const std::string hexSessionId)
+SessionIdentifier SessionManager::parseSessionId(const std::string hexSessionId)
 {
     return std::stoull(hexSessionId, nullptr, 16);
 }
 
-const SessionManager::DBusSubTreeOut
-    SessionManager::findSessionItemObjects() const
+const DBusSubTreeOut SessionManager::findSessionItemObjects() const
 {
-    constexpr const std::array sessionItemObjectIfaces = {
-        sdbusplus::xyz::openbmc_project::Session::client::Item::interface};
+    using namespace dbus;
+    using namespace sdbusplus::xyz::openbmc_project;
+
+    constexpr const std::array searchUserAssocIfaces = {
+        client::Association::interface};
+    constexpr const std::array searchSessionItemIfaces = {
+        Session::client::Item::interface};
 
     DBusSubTreeOut getSessionItemObjects;
-    auto callMethod =
-        bus.new_method_call("xyz.openbmc_project.ObjectMapper",
-                            "/xyz/openbmc_project/object_mapper",
-                            "xyz.openbmc_project.ObjectMapper", "GetSubTree");
-    callMethod.append(sessionManagerObjectPath, static_cast<int32_t>(0),
-                      sessionItemObjectIfaces);
-    bus.call(callMethod).read(getSessionItemObjects);
 
+    auto callGetManagedObjects = bus->new_method_call(
+        object_mapper::service, "/", freedesktop::objectManagerIface,
+        freedesktop::getManagedObjects);
+
+    freedesktop::ManagedObjectType managedObjectsList;
+    bus->call(callGetManagedObjects).read(managedObjectsList);
+
+    log<level::DEBUG>("Fill the ManagedObjectsList.",
+                      entry("SIZE=%d", managedObjectsList.size()));
+    for (const auto& [managedObject, objectIfaceList] : managedObjectsList)
+    {
+        if (!managedObject.str.starts_with("/xyz/openbmc_project/user") ||
+            !managedObject.str.ends_with("/session"))
+        {
+            // that is not user session object.
+            continue;
+        }
+
+        log<level::DEBUG>("Found user session object.",
+                          entry("OBJPATH=%s", managedObject.str.c_str()));
+
+        auto assocIfaceIt =
+            objectIfaceList.find(client::Association::interface);
+        if (assocIfaceIt == objectIfaceList.end())
+        {
+            log<level::DEBUG>("Found user object haven't required interface");
+            continue;
+        }
+
+        auto endpointsPropertyIt = assocIfaceIt->second.find("endpoints");
+        if (endpointsPropertyIt == assocIfaceIt->second.end())
+        {
+            log<level::DEBUG>(
+                "found association haven't the required 'endpoints' property");
+            continue;
+        }
+
+        auto sessionObjects =
+            std::get<std::vector<std::string>>(endpointsPropertyIt->second);
+        log<level::DEBUG>("Ack the SessionObjects.",
+                          entry("SIZE=%d", sessionObjects.size()));
+        for (const auto& sessionObject : sessionObjects)
+        {
+            SessionIdentifier sessionId;
+            try
+            {
+                sessionId =
+                    SessionItem::retrieveIdFromObjectPath(sessionObject);
+            }
+            catch (const std::exception& ex)
+            {
+                log<level::WARNING>("ObjectDetails: invalid object path format",
+                                    entry("ERROR=%s", ex.what()));
+                continue;
+            }
+            if (this->sessionItems.find(sessionId) != this->sessionItems.end())
+            {
+                log<level::DEBUG>(
+                    "found session is managered by the current DBus serivce.");
+                continue;
+            }
+
+            log<level::DEBUG>("Try to query session.",
+                              entry("OBJPATH=%s", sessionObject.c_str()));
+            DBusGetObjectOut getObjectOut;
+            auto callGetObject = bus->new_method_call(
+                object_mapper::service, object_mapper::object,
+                object_mapper::interface, object_mapper::getObject);
+            callGetObject.append(sessionObject, searchSessionItemIfaces);
+            try {
+                bus->call(callGetObject).read(getObjectOut);
+                getSessionItemObjects[sessionObject] = getObjectOut;
+            }
+            catch (std::exception& ex)
+            {
+                log<level::ERR>("Fail to query session info.",
+                                  entry("OBJPATH=%s", sessionObject.c_str()),
+                                  entry("ERROR=%s", ex.what()));
+            }
+        }
+    }
+
+    log<level::DEBUG>("Ack SessionItemObjects",
+                      entry("SIZE=%d", getSessionItemObjects.size()));
     return std::forward<DBusSubTreeOut>(getSessionItemObjects);
 }
 
 void SessionManager::callCloseSession(const std::string& serviceName,
-                                      const std::string& objectPath) const
+                                      const std::string& objectPath,
+                                      bool withCleanup) const
 {
     std::vector<std::string> getSessionItemObjects;
-    auto callMethod = bus.new_method_call(
+    auto callMethod = bus->new_method_call(
         serviceName.c_str(), objectPath.c_str(),
-        sdbusplus::xyz::openbmc_project::Object::client::Delete::interface,
-        "Delete");
-    bus.call_noreply(callMethod);
+        sdbusplus::xyz::openbmc_project::Session::client::Item::interface,
+        "Close");
+    callMethod.append(withCleanup);
+    bus->call_noreply(callMethod);
 }
 
-const SessionManager::DBusSessionDetailsMap
-    SessionManager::getSessionDetails(const std::string& serviceName,
-                                      const std::string& objectPath) const
+const DBusSessionDetailsMap
+    SessionManager::getSessionsProperties(const std::string& serviceName,
+                                          const std::string& objectPath) const
 {
-    SessionManager::DBusSessionDetailsMap sessionDetails;
+    DBusSessionDetailsMap sessionDetails;
 
-    auto callMethod =
-        bus.new_method_call(serviceName.c_str(), objectPath.c_str(),
-                            "org.freedesktop.DBus.Properties", "GetAll");
-    callMethod.append(
-        sdbusplus::xyz::openbmc_project::Session::client::Item::interface);
-    bus.call(callMethod).read(sessionDetails);
-    return std::forward<SessionManager::DBusSessionDetailsMap>(sessionDetails);
+    auto callMethod = bus->new_method_call(
+        serviceName.c_str(), objectPath.c_str(),
+        dbus::freedesktop::propertyIface, dbus::freedesktop::getAll);
+    // get properties of any interface
+    callMethod.append("");
+
+    bus->call(callMethod).read(sessionDetails);
+    return std::forward<DBusSessionDetailsMap>(sessionDetails);
 }
 
 void SessionManager::sessionBuildTimerStart(SessionIdentifier sessionId)
 {
+    using namespace std::chrono_literals;
+    using namespace sdbusplus::xyz::openbmc_project;
+
+    constexpr const std::array searchSessionItemIfaces = {
+        Session::client::Item::interface};
+
     this->pendingSessionBuild = true;
     this->pendingSessionId = sessionId;
     this->timerSessionComplete =
         std::thread(std::move([manager = shared_from_this()] {
-            std::this_thread::sleep_for(std::chrono::seconds(10));
-            if (manager->isSessionBuildPending())
+            std::unique_lock<std::mutex> traksactionLock(
+                manager->cvmTransaction);
+            auto waitResult = manager->cvTransaction.wait_for(
+                traksactionLock, 20s,
+                [manager] { return !manager->pendingSessionBuild; });
+            if (!waitResult)
             {
-                manager->remove(manager->pendingSessionId);
-                manager->resetPendginSessilBuild();
+                log<level::WARNING>("Timed out. Reset transaction.",
+                                    entry("SERVICE=%s", manager->slug.c_str()));
+                try
+                {
+                    manager->resetPendginSessionBuild();
+                }
+                catch (const std::exception& ex)
+                {
+                    log<level::DEBUG>("Failure to reset transaction",
+                                      entry("ERROR=%s", ex.what()));
+                }
             }
-            return true;
         }));
 
     this->timerSessionComplete.detach();
@@ -377,7 +550,166 @@ void SessionManager::sessionBuildTimerStart(SessionIdentifier sessionId)
 
 void SessionManager::sessionBuildSucess()
 {
-    resetPendginSessilBuild();
+    resetPendginSessionBuild();
+}
+
+void SessionManager::getSessionInfo(SessionIdentifier id,
+                                    InternalSessionInfo& sessionInfo) const
+{
+    if (id == 0)
+    {
+        return;
+    }
+
+    auto sessIt = this->sessionItems.find(id);
+    auto sessionPtr = sessIt->second;
+    if (sessIt != this->sessionItems.end())
+    {
+        sessionInfo.id = id;
+        sessionInfo.username = sessionPtr->getOwner();
+        sessionInfo.remoteAddress = sessionPtr->remoteIPAddr();
+        sessionInfo.type = sessionPtr->sessionType();
+        return;
+    }
+
+    auto objects = findSessionItemObjects();
+
+    log<level::DEBUG>("Count external session objects",
+                      entry("SIZE=%d", objects.size()));
+    InternalSessionInfoList sessionsList;
+    getSessionsInfo(objects, sessionsList, {{id}});
+    if (sessionsList.empty())
+    {
+        throw std::invalid_argument("Session ID not found");
+    }
+    auto sessionInfoIt = sessionsList.begin();
+    sessionInfo = sessionInfoIt->second;
+}
+
+void SessionManager::getAllSessions(InternalSessionInfoList& sessionsList) const
+{
+    for (const auto [sessionId, session] : sessionItems)
+    {
+        const auto objectPath = getSessionObjectPath(sessionId);
+        InternalSessionInfo sessionInfo{
+            sessionId,
+            session->getOwner(),
+            session->remoteIPAddr(),
+            session->sessionType(),
+            serviceName,
+            objectPath,
+            true,
+        };
+        sessionsList.emplace(sessionId, sessionInfo);
+    }
+
+    const auto sessionObjects = findSessionItemObjects();
+    getSessionsInfo(sessionObjects, sessionsList);
+}
+
+void SessionManager::getSessionsInfo(
+    const DBusSubTreeOut& sessionSubTree, InternalSessionInfoList& sessionsList,
+    std::optional<std::vector<SessionIdentifier>> listSearchingSessions) const
+{
+    for (const auto& [sessionObjectPath, objectMetaDict] : sessionSubTree)
+    {
+        std::function<bool(SessionIdentifier id)> matchSessionId =
+            [sessionObjectPath](SessionIdentifier id) -> bool {
+            return id > 0 && sessionObjectPath.ends_with(hexSessionId(id));
+        };
+        if (objectMetaDict.empty() ||
+            (listSearchingSessions.has_value() &&
+             !std::any_of(listSearchingSessions->begin(),
+                          listSearchingSessions->end(), matchSessionId)))
+        {
+            log<level::DEBUG>("Skip loop objects",
+                              entry("OBJPATH=%s", sessionObjectPath.c_str()));
+            continue;
+        }
+        const auto& svcName = objectMetaDict.begin()->first;
+        log<level::DEBUG>("Examinate object to obtain session info",
+                          entry("OBJPATH=%s", sessionObjectPath.c_str()),
+                          entry("SERVICE=%s", svcName.c_str()));
+        const auto details = getSessionsProperties(svcName, sessionObjectPath);
+        log<level::DEBUG>("Count properties of ObjectDetails",
+                          entry("COUNT=%d", details.size()));
+        SessionIdentifier sessionId;
+        try
+        {
+            sessionId =
+                SessionItem::retrieveIdFromObjectPath(sessionObjectPath);
+        }
+        catch (const std::exception& ex)
+        {
+            log<level::WARNING>("ObjectDetails: invalid object path format",
+                                entry("ERROR=%s", ex.what()));
+            continue;
+        }
+        InternalSessionInfo sessionInfo{sessionId};
+        sessionInfo.serviceName = svcName;
+        sessionInfo.objectPath = sessionObjectPath;
+        sessionInfo.isOwn = false;
+        for (const auto& [propertyName, propertyValue] : details)
+        {
+            if (propertyName == "Associations")
+            {
+                log<level::DEBUG>("Found Session item associations");
+                const UserAssociationList* userAssociations =
+                    std::get_if<UserAssociationList>(&propertyValue);
+                if (userAssociations == nullptr)
+                {
+                    log<level::WARNING>("Bad association: nullptr. skip");
+                    continue;
+                }
+
+                for (const auto& userAssociation : *userAssociations)
+                {
+                    const std::string assocType = std::get<0>(userAssociation);
+                    if (assocType == std::string("user"))
+                    {
+                        log<level::DEBUG>("User association: OK");
+                        try
+                        {
+                            const std::string userObjectPath =
+                                std::get<2>(userAssociation);
+                            sessionInfo.username =
+                                SessionItem::retrieveUserFromObjectPath(
+                                    userObjectPath);
+                            break;
+                        }
+                        catch (const std::exception& ex)
+                        {
+                            log<level::WARNING>(
+                                "ObjectDetails: Failure to get User field",
+                                entry("ERROR=%s", ex.what()),
+                                entry("FIELD=%s", "UserObjectPath"));
+                        }
+                    }
+                }
+            }
+            else if (propertyName == "RemoteIPAddr")
+            {
+                const std::string* remoteAddressValue =
+                    std::get_if<std::string>(&propertyValue);
+                if (remoteAddressValue != nullptr)
+                {
+                    sessionInfo.remoteAddress = *remoteAddressValue;
+                }
+            }
+            else if (propertyName == "SessionType")
+            {
+                const std::string* sessionTypeValue =
+                    std::get_if<std::string>(&propertyValue);
+                if (sessionTypeValue != nullptr)
+                {
+                    sessionInfo.type =
+                        sdbusplus::xyz::openbmc_project::Session::server::Item::
+                            convertTypeFromString(*sessionTypeValue);
+                }
+            }
+        }
+        sessionsList.emplace(sessionId, sessionInfo);
+    }
 }
 
 } // namespace session

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (C) 2021 YADRO
 
-#include <src/session.hpp>
+#include <libobmcsession/session.hpp>
+#include <iostream>
 
 namespace obmc
 {
@@ -9,15 +10,11 @@ namespace session
 {
 void SessionItem::delete_()
 {
-    auto manager = managerWeakPtr.lock();
-    if (manager)
+    SessionManager::SessionIdentifier sessionId =
+        SessionManager::parseSessionId(this->sessionID());
+    if (!managerPtr->remove(sessionId))
     {
-        SessionManager::SessionIdentifier sessionId =
-            SessionManager::parseSessionId(this->sessionID());
-        if (!manager->remove(sessionId))
-        {
-            throw InternalFailure();
-        }
+        throw InternalFailure();
     }
 }
 

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -1,31 +1,54 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (C) 2021 YADRO
 
-#include <libobmcsession/session.hpp>
+#include <dbus.hpp>
+#include <session.hpp>
+
 #include <iostream>
+
+#include <phosphor-logging/elog-errors.hpp>
+#include <phosphor-logging/log.hpp>
 
 namespace obmc
 {
 namespace session
 {
-void SessionItem::delete_()
+
+using namespace phosphor::logging;
+
+void SessionItem::close(bool handle)
 {
-    SessionManager::SessionIdentifier sessionId =
+    SessionIdentifier sessionId =
         SessionManager::parseSessionId(this->sessionID());
-    if (!managerPtr->remove(sessionId))
+
+    log<level::DEBUG>("SessionItem::close()", entry("SESSIONID=%d", sessionId),
+                      entry("ISCLEANUP=%d", handle));
+
+    auto cleanupFnPtr = cleanupFn;
+    if (!handle && cleanupFn)
     {
+        resetCleanupFn(nullptr);
+    }
+    if (!managerPtr->remove(sessionId, handle, true))
+    {
+        // Restore cleanup function if something fail.
+        resetCleanupFn(std::forward<SessionCleanupFn>(cleanupFnPtr));
         throw InternalFailure();
     }
 }
 
 void SessionItem::setSessionMetadata(std::string username,
-                                     uint32_t remoteIPAddr)
+                                     std::string remoteIPAddr)
 {
     this->adjustSessionOwner(username);
+    if (remoteIPAddr.empty())
+    {
+        throw InvalidArgument();
+    }
     this->remoteIPAddr(remoteIPAddr);
 }
 
-void SessionItem::resetCleanupFn(SessionManager::SessionCleanupFn&& cleanup)
+void SessionItem::resetCleanupFn(SessionCleanupFn&& cleanup)
 {
     this->cleanupFn = cleanup;
 }
@@ -48,13 +71,42 @@ void SessionItem::adjustSessionOwner(const std::string& userName)
 
     if (getUserObject.empty())
     {
-        throw std::runtime_error("The username '" + userName +
-                                 "' is not found");
+        throw UnknownUser();
     }
 
     this->associations({
         make_tuple("user", "session", userObjectPath),
     });
+}
+
+const std::string SessionItem::getOwner() const
+{
+    for (const auto assocTuple : associations())
+    {
+        const std::string assocType = std::get<0>(assocTuple);
+        if (assocType != std::string("user"))
+        {
+            continue;
+        }
+        const std::string userObjectPath = std::get<2>(assocTuple);
+
+        return retrieveUserFromObjectPath(userObjectPath);
+    }
+
+    throw std::logic_error("The username has not been set.");
+}
+
+const std::string
+    SessionItem::retrieveUserFromObjectPath(const std::string& objectPath)
+{
+    return dbus::utils::getLastSegmentFromObjectPath(objectPath);
+}
+
+SessionIdentifier
+    SessionItem::retrieveIdFromObjectPath(const std::string& objectPath)
+{
+    return SessionManager::parseSessionId(
+        dbus::utils::getLastSegmentFromObjectPath(objectPath));
 }
 
 } // namespace session

--- a/src/session.hpp
+++ b/src/session.hpp
@@ -5,30 +5,37 @@
 
 #include <unistd.h>
 
-#include <libobmcsession/manager.hpp>
+#include <phosphor-logging/elog-errors.hpp>
+#include <phosphor-logging/log.hpp>
+
+#include <manager.hpp>
 #include <xyz/openbmc_project/Association/Definitions/server.hpp>
-#include <xyz/openbmc_project/Common/error.hpp>
-#include <xyz/openbmc_project/Object/Delete/server.hpp>
 
 namespace obmc
 {
 namespace session
 {
 
+using namespace phosphor::logging;
+
 using SessionItemServerObject =
     sdbusplus::server::object::object<SessionItemServer>;
 using AssocDefinitionServerObject = sdbusplus::server::object::object<
     sdbusplus::xyz::openbmc_project::Association::server::Definitions>;
 
-using DeleteServerObject = sdbusplus::server::object::object<
-    sdbusplus::xyz::openbmc_project::Object::server::Delete>;
-using InternalFailure =
-    sdbusplus::xyz::openbmc_project::Common::Error::InternalFailure;
+class UnknownUser: public std::logic_error
+{
+    static constexpr auto errDesc = "Unkown username was given.";
+
+  public:
+    UnknownUser(): std::logic_error(errDesc)
+    {}
+    ~UnknownUser() override = default;
+};
 
 class SessionItem :
     public SessionItemServerObject,
-    public AssocDefinitionServerObject,
-    public DeleteServerObject
+    public AssocDefinitionServerObject
 {
   public:
     SessionItem() = delete;
@@ -46,9 +53,8 @@ class SessionItem :
     SessionItem(sdbusplus::bus::bus& bus, const std::string& objPath,
                 SessionManagerPtr managerPtr) :
         SessionItemServerObject(bus, objPath.c_str()),
-        AssocDefinitionServerObject(bus, objPath.c_str()),
-        DeleteServerObject(bus, objPath.c_str()), bus(bus), path(objPath),
-        managerPtr(managerPtr)
+        AssocDefinitionServerObject(bus, objPath.c_str()), bus(bus),
+        path(objPath), managerPtr(managerPtr)
     {
         // Nothing to do here
     }
@@ -63,12 +69,10 @@ class SessionItem :
      *                            removal.
      */
     SessionItem(sdbusplus::bus::bus& bus, const std::string& objPath,
-                SessionManagerPtr managerPtr,
-                SessionManager::SessionCleanupFn&& cleanupFn) :
+                SessionManagerPtr managerPtr, SessionCleanupFn&& cleanupFn) :
         SessionItemServerObject(bus, objPath.c_str()),
-        AssocDefinitionServerObject(bus, objPath.c_str()),
-        DeleteServerObject(bus, objPath.c_str()), bus(bus), path(objPath),
-        managerPtr(managerPtr), cleanupFn(cleanupFn)
+        AssocDefinitionServerObject(bus, objPath.c_str()), bus(bus),
+        path(objPath), managerPtr(managerPtr), cleanupFn(cleanupFn)
     {
         // Nothing to do here
     }
@@ -77,31 +81,31 @@ class SessionItem :
     {
         if (cleanupFn != nullptr)
         {
-            std::invoke(cleanupFn, identifier);
+            SessionIdentifier sessionId =
+                SessionManager::parseSessionId(this->sessionID());
+            std::invoke(cleanupFn, sessionId);
         }
     }
 
-    /**
-     * @brief callback to delete object of the
-     *        `xyz.openbmc_project.Object.Delete` dbus interface method
+    /** @brief Close the exist session.
      *
+     *  @param[in] handle   - Specifies it is required to post-processing the
+     *                        session closing  with the configured handler.
      */
-    void delete_() override;
+    void close(bool handle) override;
 
-    /** @brief Implementation for SetSessionMetadata
-     *         Set Username and Remote IP addres of exist session.
+    /** @brief Set Username and Remote IP addres of exist session.
      *
      *  @param[in] username         - Owner username of the session
      *  @param[in] remoteIPAddr     - Remote IP address.
      */
-    void setSessionMetadata(std::string username,
-                            uint32_t remoteIPAddr) override;
+    void setSessionMetadata(std::string username, std::string remoteIPAddr);
 
     /**
      * @brief Callback function to a session cleanup on the close.
      *
      */
-    void resetCleanupFn(SessionManager::SessionCleanupFn&&);
+    void resetCleanupFn(SessionCleanupFn&&);
 
     /**
      * @brief Associate user of specified username with the current session.
@@ -114,13 +118,27 @@ class SessionItem :
      */
     void adjustSessionOwner(const std::string& userName);
 
+    /** 
+     * @brief Get the session owner username
+     * 
+     * @throw logic_error       - the username has not been set.
+     * 
+     * @return std::string      - the session username
+     */ 
+    const std::string getOwner() const;
+
+    static const std::string
+        retrieveUserFromObjectPath(const std::string& objectPath);
+
+    static SessionIdentifier
+        retrieveIdFromObjectPath(const std::string& objectPath);
+
   private:
-    SessionManager::SessionIdentifier identifier;
     sdbusplus::bus::bus& bus;
     /** @brief Path of the group instance */
     const std::string path;
     SessionManagerPtr managerPtr;
-    SessionManager::SessionCleanupFn cleanupFn;
+    SessionCleanupFn cleanupFn;
 };
 
 } // namespace session


### PR DESCRIPTION
In some cases creating a session might be from different services. It
requires to be a transaction pattern.
This patch brings the implementation of creating a session in
a transaction and a little bit of refactoring.

End-user-impact: None

Signed-off-by: Igor Kononenko <i.kononenko@yadro.com>